### PR TITLE
Use filename if there is no title in the Markdown file

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -20,12 +20,18 @@ const getDirTitle = path =>
     .chain(x => Maybe.fromNullable(x[x.length - 2]))
     .getOrElse('NO_NAME') // shouldn't happen, right !?
 
+const getFileName = path =>
+  Maybe.of(path.split('/'))
+    .chain(x => Maybe.fromNullable(x[x.length - 1]))
+    .getOrElse('NO_NAME') // shouldn't happen, right !?
+
 // (String -> Bool) -> [ String, Markdown ] -> String
 const fileEntry = isReadme => ([ filePath, parsedMarkdown ]) => {
   if (isReadme(filePath)) return
 
   const depth = getFileDepth(filePath)
-  const fileTitle = getFileTitle(parsedMarkdown)
+  console.log(filePath, parsedMarkdown);
+  const fileTitle = getFileTitle(parsedMarkdown) || getFileName(filePath)
 
   return linkEntries(depth, fileTitle, filePath)
 }
@@ -34,8 +40,9 @@ const getFileTitle = parsedMarkdown =>
   parsedMarkdown
     .chain(m => Maybe.fromNullable(m.headings))
     .map(headings => headings[0])
+    .filter(title => !!title)
     .map(title => title.trim())
-    .getOrElse('NO_NAME')
+    .getOrElse(null)
 
 const depthEntries = (depth, entries) =>
   Array(depth).join('    ') + entries

--- a/renderer.js
+++ b/renderer.js
@@ -30,8 +30,8 @@ const fileEntry = isReadme => ([ filePath, parsedMarkdown ]) => {
   if (isReadme(filePath)) return
 
   const depth = getFileDepth(filePath)
-  console.log(filePath, parsedMarkdown);
-  const fileTitle = getFileTitle(parsedMarkdown) || getFileName(filePath)
+  const fileTitle = getFileTitle(parsedMarkdown)
+    .getOrElse(getFileName(filePath))
 
   return linkEntries(depth, fileTitle, filePath)
 }
@@ -42,7 +42,6 @@ const getFileTitle = parsedMarkdown =>
     .map(headings => headings[0])
     .filter(title => !!title)
     .map(title => title.trim())
-    .getOrElse(null)
 
 const depthEntries = (depth, entries) =>
   Array(depth).join('    ') + entries


### PR DESCRIPTION
If the filename is empty in the markdown file, an error `Cannot read property 'trim' of undefined [...] renderer.js:37`

I fixed it by using the filename if there is no title in the markdown file which seems to be the most relevant option.

Thank you